### PR TITLE
Make assets self-contained for static hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# AniRanker Static Site
+
+AniRanker is a purely static React experience that can be hosted anywhere GitHub Pages can serve HTML, CSS, and JavaScript files. All data used by the interface is bundled directly into the repository, so no server-side runtime or build tooling is required.
+
+## Project structure
+
+```
+.
+├── index.html        # Entry point that loads React from a CDN and mounts the app
+├── styles.css        # Global styles for the entire experience
+└── src/
+    ├── api/          # Local mock implementations that provide data to the UI
+    ├── components/   # React components written without a build step
+    ├── data/         # Curated anime and waifu data sets served from static JS modules
+    └── utils/        # Shared helpers, e.g. SVG placeholder generators
+```
+
+## Local development
+
+Because everything is static, you can either open `index.html` directly in your browser or serve the directory with a very small HTTP server. For example:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then visit [http://localhost:8000](http://localhost:8000) to interact with the site.
+
+## Deploying to GitHub Pages
+
+1. Push the repository to GitHub.
+2. Open the repository settings and navigate to the **Pages** section.
+3. Under **Source**, choose **Deploy from a branch**.
+4. Select the default branch (usually `main`) and the `/ (root)` folder, then click **Save**.
+5. GitHub Pages will build and publish the static site automatically. Once the deployment completes, your site will be available at `https://<username>.github.io/<repository>/`.
+
+That’s it—no build scripts or additional configuration are needed.

--- a/src/api/anilist.js
+++ b/src/api/anilist.js
@@ -1,4 +1,5 @@
 import { ANIME } from '../data/anime.js';
+import { createPortraitPlaceholder } from '../utils/placeholders.js';
 
 const imageCache = new Map();
 
@@ -64,7 +65,7 @@ export async function fetchCharacterImage(name) {
     return imageCache.get(name);
   }
 
-  const placeholder = `https://placehold.co/256x256?text=${encodeURIComponent(name)}`;
+  const placeholder = createPortraitPlaceholder(name);
   imageCache.set(name, placeholder);
   return placeholder;
 }

--- a/src/data/anime.js
+++ b/src/data/anime.js
@@ -1,4 +1,6 @@
-const cover = (text) => `https://placehold.co/300x450?text=${encodeURIComponent(text)}`;
+import { createCoverPlaceholder } from '../utils/placeholders.js';
+
+const cover = (text) => createCoverPlaceholder(text);
 
 export const ANIME = [
   {

--- a/src/utils/placeholders.js
+++ b/src/utils/placeholders.js
@@ -1,0 +1,157 @@
+const ESCAPE_MAP = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&apos;',
+};
+
+const escapeXml = (value) =>
+  String(value ?? '')
+    .split('')
+    .map((char) => ESCAPE_MAP[char] ?? char)
+    .join('');
+
+const toDisplayLine = (value) => escapeXml(String(value ?? '').toUpperCase());
+
+const wrapText = (value, maxLength, maxLines) => {
+  const normalized = String(value ?? '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!normalized) {
+    return [];
+  }
+
+  const words = normalized.split(' ');
+  const lines = [];
+  let current = '';
+
+  for (const rawWord of words) {
+    if (!rawWord) {
+      continue;
+    }
+
+    let word = rawWord;
+    while (word.length > maxLength) {
+      const segment = word.slice(0, maxLength);
+      word = word.slice(maxLength);
+
+      if (current) {
+        lines.push(current);
+        current = '';
+      }
+
+      lines.push(segment);
+      if (lines.length >= maxLines) {
+        return lines.slice(0, maxLines).map(toDisplayLine);
+      }
+    }
+
+    if (!word) {
+      continue;
+    }
+
+    const candidate = current ? `${current} ${word}` : word;
+    if (candidate.length <= maxLength) {
+      current = candidate;
+    } else {
+      if (current) {
+        lines.push(current);
+        if (lines.length >= maxLines) {
+          return lines.slice(0, maxLines).map(toDisplayLine);
+        }
+      }
+      current = word;
+    }
+  }
+
+  if (current && lines.length < maxLines) {
+    lines.push(current);
+  }
+
+  return lines.slice(0, maxLines).map(toDisplayLine);
+};
+
+const buildPlaceholder = ({
+  width,
+  height,
+  text,
+  background,
+  accent,
+  textColor,
+  borderRadius,
+  fontSize,
+  lineHeight,
+  maxLineLength,
+  maxLines,
+  fallbackLabel,
+}) => {
+  const lines = wrapText(text, maxLineLength, maxLines);
+  const displayLines =
+    lines.length > 0 ? lines : [toDisplayLine(fallbackLabel)];
+  const accessibleLabel = escapeXml(text || fallbackLabel);
+  const lineCount = displayLines.length;
+  const spacing = lineHeight;
+  const startOffset = -((lineCount - 1) * spacing) / 2;
+
+  const tspanElements = displayLines
+    .map((line, index) => {
+      const dy = index === 0 ? `${startOffset}em` : `${spacing}em`;
+      return `<tspan x="50%" dy="${dy}">${line}</tspan>`;
+    })
+    .join('');
+
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}" role="img" aria-label="${accessibleLabel}">` +
+    `<defs>` +
+    `<linearGradient id="gradient" x1="0" y1="0" x2="1" y2="1">` +
+    `<stop offset="0%" stop-color="${background}" />` +
+    `<stop offset="100%" stop-color="${accent}" />` +
+    `</linearGradient>` +
+    `</defs>` +
+    `<rect width="100%" height="100%" fill="url(#gradient)" rx="${borderRadius}" ry="${borderRadius}" />` +
+    `<text x="50%" y="50%" fill="${textColor}" font-family="'Inter','Segoe UI',sans-serif" font-size="${fontSize}" font-weight="600" text-anchor="middle" dominant-baseline="middle">` +
+    `${tspanElements}` +
+    `</text>` +
+    `</svg>`;
+
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+};
+
+export const createCoverPlaceholder = (text) =>
+  buildPlaceholder({
+    width: 300,
+    height: 450,
+    text,
+    background: '#f4f5f8',
+    accent: '#e0e5ef',
+    textColor: '#1f2937',
+    borderRadius: 28,
+    fontSize: 28,
+    lineHeight: 1.2,
+    maxLineLength: 18,
+    maxLines: 3,
+    fallbackLabel: 'AniRanker',
+  });
+
+export const createPortraitPlaceholder = (text) =>
+  buildPlaceholder({
+    width: 256,
+    height: 256,
+    text,
+    background: '#f7efe2',
+    accent: '#e8d7bd',
+    textColor: '#3a2f21',
+    borderRadius: 32,
+    fontSize: 32,
+    lineHeight: 1.2,
+    maxLineLength: 12,
+    maxLines: 3,
+    fallbackLabel: 'Portrait',
+  });
+
+export default {
+  createCoverPlaceholder,
+  createPortraitPlaceholder,
+};


### PR DESCRIPTION
## Summary
- add reusable SVG placeholder generator so covers and portraits are created locally without remote services
- update the anime dataset and character image loader to use the local placeholders for offline-friendly rendering
- document how to serve the static site and deploy it via GitHub Pages

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c98664525c8324922d01491f775021