### PR TITLE
Add release status filters to anime search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AniRanker Static Site
 
-AniRanker is a purely static experience built with modern browser APIs that can be hosted anywhere GitHub Pages can serve HTML, CSS, and JavaScript files. All data used by the interface is bundled directly into the repository, so no server-side runtime or build tooling is required.
+AniRanker is a purely static experience built with modern browser APIs that can be hosted anywhere GitHub Pages can serve HTML, CSS, and JavaScript files. All data used by the interface is bundled directly into the repository, so no server-side runtime or build tooling is required. Powerful yet lightweight filters—covering search keywords, genres, and release status—help you curate the catalogue without needing any backend services.
 
 ## Project structure
 

--- a/src/api/anilist.js
+++ b/src/api/anilist.js
@@ -9,6 +9,10 @@ const ALL_GENRES = Array.from(
   )
 ).sort((a, b) => a.localeCompare(b));
 
+const ALL_STATUSES = Array.from(new Set(ANIME.map((item) => item.status).filter(Boolean))).sort(
+  (a, b) => a.localeCompare(b)
+);
+
 const cloneAnime = (anime) => JSON.parse(JSON.stringify(anime));
 
 const normalize = (value) => (typeof value === 'string' ? value.toLowerCase() : '');
@@ -31,16 +35,30 @@ const matchesGenres = (anime, genres) => {
   return genres.every((genre) => list.includes(genre));
 };
 
+const matchesStatuses = (anime, statuses) => {
+  if (!statuses || statuses.length === 0) {
+    return true;
+  }
+  if (!anime.status) {
+    return false;
+  }
+  return statuses.includes(anime.status);
+};
+
 export async function searchAnime(query, options = {}) {
   const normalizedQuery = normalize(query ? query.trim() : '');
   const requestedGenres = Array.isArray(options.genres) ? options.genres : [];
+  const requestedStatuses = Array.isArray(options.statuses) ? options.statuses : [];
   const page = options.page && options.page > 0 ? options.page : 1;
   const perPage = options.perPage && options.perPage > 0 ? options.perPage : 20;
   const start = (page - 1) * perPage;
   const end = start + perPage;
 
   const filtered = ANIME.filter(
-    (item) => matchesQuery(item, normalizedQuery) && matchesGenres(item, requestedGenres)
+    (item) =>
+      matchesQuery(item, normalizedQuery) &&
+      matchesGenres(item, requestedGenres) &&
+      matchesStatuses(item, requestedStatuses)
   );
 
   return filtered.slice(start, end).map(cloneAnime);
@@ -54,6 +72,10 @@ export async function getAnimeById(id) {
 
 export async function fetchGenres() {
   return ALL_GENRES.slice();
+}
+
+export async function fetchStatuses() {
+  return ALL_STATUSES.slice();
 }
 
 export async function fetchCharacterImage(name) {

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,10 @@
-import { fetchCharacterImage, fetchGenres, getAnimeById, searchAnime } from './api/anilist.js';
+import {
+  fetchCharacterImage,
+  fetchGenres,
+  fetchStatuses,
+  getAnimeById,
+  searchAnime,
+} from './api/anilist.js';
 import { WAIFUS, sortWaifuList, WAIFU_ATTRIBUTE_LABELS } from './data/waifus.js';
 import Icons from './icons.js';
 
@@ -12,6 +18,8 @@ class AniRankerApp {
       error: null,
       genreOptions: [],
       selectedGenres: [],
+      statusOptions: [],
+      selectedStatuses: [],
       sortBy: 'POPULARITY',
       ratings: {},
       waifuSelection: '',
@@ -56,6 +64,7 @@ class AniRankerApp {
     this.createLayout();
     this.render();
     this.loadGenres();
+    this.loadStatuses();
     this.scheduleAnimeSearch();
     this.bindGlobalEvents();
   }
@@ -111,12 +120,13 @@ class AniRankerApp {
   performAnimeSearch() {
     const query = this.state.searchTerm;
     const genres = this.state.selectedGenres.slice();
+    const statuses = this.state.selectedStatuses.slice();
     const token = Symbol('search');
     this.activeSearchToken = token;
 
     this.setState({ isLoading: true, error: null });
 
-    searchAnime(query, { perPage: 24, genres })
+    searchAnime(query, { perPage: 24, genres, statuses })
       .then((results) => {
         if (this.activeSearchToken !== token) {
           return;
@@ -145,6 +155,19 @@ class AniRankerApp {
       })
       .catch((error) => {
         console.error('Failed to load genres', error);
+      });
+  }
+
+  loadStatuses() {
+    fetchStatuses()
+      .then((statuses) => {
+        if (Array.isArray(statuses) && statuses.length > 0) {
+          const list = statuses.slice();
+          this.setState({ statusOptions: list });
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to load statuses', error);
       });
   }
 
@@ -328,9 +351,20 @@ class AniRankerApp {
     genresField.appendChild(genresLabel);
     genresField.appendChild(this.genreChipList);
 
+    const statusField = document.createElement('div');
+    statusField.className = 'filter-bar__statuses field';
+    const statusLabel = document.createElement('span');
+    statusLabel.className = 'field__label';
+    statusLabel.textContent = 'Status';
+    this.statusChipList = document.createElement('div');
+    this.statusChipList.className = 'chip-list';
+    statusField.appendChild(statusLabel);
+    statusField.appendChild(this.statusChipList);
+
     section.appendChild(searchField);
     section.appendChild(sortField);
     section.appendChild(genresField);
+    section.appendChild(statusField);
     return section;
   }
 
@@ -693,6 +727,31 @@ class AniRankerApp {
         this.genreChipList.appendChild(label);
       });
     }
+
+    this.statusChipList.innerHTML = '';
+    if (this.state.statusOptions.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'chip-list__empty';
+      empty.textContent = 'Statuses will appear once content loads.';
+      this.statusChipList.appendChild(empty);
+    } else {
+      this.state.statusOptions.forEach((status) => {
+        const isActive = this.state.selectedStatuses.includes(status);
+        const label = document.createElement('label');
+        label.className = isActive ? 'chip chip--active' : 'chip';
+        const icon = Icons.Tag({ className: 'chip__icon', 'aria-hidden': 'true' });
+        const text = document.createElement('span');
+        text.textContent = status;
+        const input = document.createElement('input');
+        input.type = 'checkbox';
+        input.checked = isActive;
+        input.addEventListener('change', () => this.toggleStatus(status));
+        label.appendChild(icon);
+        label.appendChild(text);
+        label.appendChild(input);
+        this.statusChipList.appendChild(label);
+      });
+    }
   }
 
   renderAnimeSection() {
@@ -1006,6 +1065,15 @@ class AniRankerApp {
       ? current.filter((item) => item !== genre)
       : current.concat(genre);
     this.setState({ selectedGenres: next });
+    this.scheduleAnimeSearch();
+  }
+
+  toggleStatus(status) {
+    const current = this.state.selectedStatuses;
+    const next = current.includes(status)
+      ? current.filter((item) => item !== status)
+      : current.concat(status);
+    this.setState({ selectedStatuses: next });
     this.scheduleAnimeSearch();
   }
 

--- a/styles.css
+++ b/styles.css
@@ -476,7 +476,8 @@ button.waifu-pill:focus-visible {
   transform: translateY(-50%);
 }
 
-.filter-bar__genres {
+.filter-bar__genres,
+.filter-bar__statuses {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -873,7 +874,8 @@ button.waifu-pill:focus-visible {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .filter-bar__genres {
+  .filter-bar__genres,
+  .filter-bar__statuses {
     grid-column: 1 / -1;
   }
 }


### PR DESCRIPTION
## Summary
- add release status metadata and filtering support to the local AniList mock API
- surface a release status chip group in the filter bar and include its selections in anime searches
- document the richer filtering options available in the static experience

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9a9427e588324b25619691db8701e