### PR TITLE
Add anime theme switcher and enhance UI motion

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,9 +2,134 @@ import { fetchCharacterImage, fetchGenres, getAnimeById, searchAnime } from './a
 import { WAIFUS, sortWaifuList, WAIFU_ATTRIBUTE_LABELS } from './data/waifus.js';
 import Icons from './icons.js';
 
+const THEME_PRESETS = [
+  {
+    id: 'naruto',
+    label: 'Naruto',
+    tagline: 'Leaf Village sunrise',
+    swatches: ['#ff9440', '#233d7b', '#ffd37d', '#1c1b2a'],
+    palette: {
+      '--app-background': 'radial-gradient(circle at 12% 12%, #fff1e0 0%, #ffd7b3 45%, #ffb38a 100%)',
+      '--surface': '#fff8ef',
+      '--surface-muted': '#ffe2c4',
+      '--surface-gradient': 'linear-gradient(160deg, rgba(255, 250, 242, 0.95) 0%, rgba(255, 220, 188, 0.9) 100%)',
+      '--accent': '#ff9440',
+      '--accent-strong': '#ef6722',
+      '--accent-soft': 'rgba(255, 148, 64, 0.22)',
+      '--text-main': '#261a17',
+      '--text-muted': '#7a5241',
+      '--border': '#f2bb8c',
+      '--border-strong': '#e98d45',
+      '--shadow-soft': '0 25px 60px rgba(251, 124, 32, 0.22)',
+      '--shadow-sharp': '0 12px 30px rgba(243, 120, 28, 0.32)',
+      '--hero-glow': 'rgba(255, 148, 64, 0.45)',
+      '--hero-glow-secondary': 'rgba(255, 196, 133, 0.35)',
+      '--focus-ring': 'rgba(255, 148, 64, 0.45)',
+    },
+  },
+  {
+    id: 'one-piece',
+    label: 'One Piece',
+    tagline: 'Treasure fleet skies',
+    swatches: ['#47c7ff', '#ffd73d', '#ff6f61', '#072149'],
+    palette: {
+      '--app-background': 'radial-gradient(circle at 20% 10%, #f0fbff 0%, #c9e9ff 42%, #fff4d6 100%)',
+      '--surface': '#ffffff',
+      '--surface-muted': '#e7f3ff',
+      '--surface-gradient': 'linear-gradient(160deg, rgba(255, 255, 255, 0.95) 0%, rgba(220, 236, 255, 0.9) 100%)',
+      '--accent': '#ffd73d',
+      '--accent-strong': '#ff8b6a',
+      '--accent-soft': 'rgba(71, 199, 255, 0.2)',
+      '--text-main': '#072149',
+      '--text-muted': '#4f6c8b',
+      '--border': '#bad9ff',
+      '--border-strong': '#6bb8ff',
+      '--shadow-soft': '0 25px 60px rgba(28, 128, 197, 0.18)',
+      '--shadow-sharp': '0 14px 32px rgba(71, 199, 255, 0.35)',
+      '--hero-glow': 'rgba(71, 199, 255, 0.38)',
+      '--hero-glow-secondary': 'rgba(255, 221, 61, 0.35)',
+      '--focus-ring': 'rgba(71, 199, 255, 0.45)',
+    },
+  },
+  {
+    id: 'dragon-ball',
+    label: 'Dragon Ball',
+    tagline: 'Super Saiyan charge',
+    swatches: ['#ff9a1f', '#3056ff', '#1ed27e', '#1f2233'],
+    palette: {
+      '--app-background': 'radial-gradient(circle at 10% 90%, #fff4dc 0%, #ffd289 45%, #f0edff 100%)',
+      '--surface': '#fff6eb',
+      '--surface-muted': '#ffe1bd',
+      '--surface-gradient': 'linear-gradient(160deg, rgba(255, 244, 219, 0.95) 0%, rgba(255, 217, 150, 0.9) 100%)',
+      '--accent': '#ff9a1f',
+      '--accent-strong': '#3056ff',
+      '--accent-soft': 'rgba(255, 154, 31, 0.24)',
+      '--text-main': '#1f2233',
+      '--text-muted': '#57566b',
+      '--border': '#f2bf81',
+      '--border-strong': '#d98b3a',
+      '--shadow-soft': '0 25px 60px rgba(255, 126, 27, 0.22)',
+      '--shadow-sharp': '0 14px 32px rgba(48, 86, 255, 0.28)',
+      '--hero-glow': 'rgba(255, 154, 31, 0.4)',
+      '--hero-glow-secondary': 'rgba(48, 86, 255, 0.3)',
+      '--focus-ring': 'rgba(48, 86, 255, 0.45)',
+    },
+  },
+  {
+    id: 'bleach',
+    label: 'Bleach',
+    tagline: 'Soul Society edge',
+    swatches: ['#101217', '#f56c3b', '#8fbbe8', '#f7efe6'],
+    palette: {
+      '--app-background': 'radial-gradient(circle at 85% 15%, #fff7ef 0%, #ffe0d1 40%, #d3e4ff 100%)',
+      '--surface': '#fffdf8',
+      '--surface-muted': '#f0f2f7',
+      '--surface-gradient': 'linear-gradient(160deg, rgba(255, 255, 255, 0.95) 0%, rgba(240, 244, 250, 0.95) 100%)',
+      '--accent': '#f56c3b',
+      '--accent-strong': '#0f1116',
+      '--accent-soft': 'rgba(245, 108, 59, 0.26)',
+      '--text-main': '#101217',
+      '--text-muted': '#596273',
+      '--border': '#d5dcea',
+      '--border-strong': '#a9b6cf',
+      '--shadow-soft': '0 24px 60px rgba(16, 18, 23, 0.18)',
+      '--shadow-sharp': '0 14px 32px rgba(245, 108, 59, 0.28)',
+      '--hero-glow': 'rgba(16, 18, 23, 0.45)',
+      '--hero-glow-secondary': 'rgba(245, 108, 59, 0.32)',
+      '--focus-ring': 'rgba(245, 108, 59, 0.45)',
+    },
+  },
+  {
+    id: 'attack-on-titan',
+    label: 'Attack on Titan',
+    tagline: 'Scout Regiment resolve',
+    swatches: ['#2f4636', '#8c6f52', '#d5c5ac', '#5d5f58'],
+    palette: {
+      '--app-background': 'radial-gradient(circle at 50% 100%, #f4f0e6 0%, #dcd3c2 45%, #c6d9cd 100%)',
+      '--surface': '#fdf9f0',
+      '--surface-muted': '#ece4d6',
+      '--surface-gradient': 'linear-gradient(160deg, rgba(253, 249, 240, 0.95) 0%, rgba(230, 222, 206, 0.9) 100%)',
+      '--accent': '#2f4636',
+      '--accent-strong': '#8c6f52',
+      '--accent-soft': 'rgba(47, 70, 54, 0.22)',
+      '--text-main': '#2b2d2a',
+      '--text-muted': '#5d5f58',
+      '--border': '#c6baa4',
+      '--border-strong': '#8c6f52',
+      '--shadow-soft': '0 24px 60px rgba(47, 70, 54, 0.18)',
+      '--shadow-sharp': '0 14px 32px rgba(140, 111, 82, 0.28)',
+      '--hero-glow': 'rgba(47, 70, 54, 0.45)',
+      '--hero-glow-secondary': 'rgba(158, 197, 161, 0.35)',
+      '--focus-ring': 'rgba(140, 111, 82, 0.45)',
+    },
+  },
+];
+
 class AniRankerApp {
   constructor(rootElement) {
     this.rootElement = rootElement;
+    this.themePresets = THEME_PRESETS.slice();
+    const initialTheme = this.themePresets.length > 0 ? this.themePresets[0].id : null;
     this.state = {
       searchTerm: '',
       anime: [],
@@ -31,7 +156,9 @@ class AniRankerApp {
       detailData: null,
       detailLoading: false,
       detailError: null,
+      activeTheme: initialTheme,
     };
+    this.themeSwitcherList = null;
 
     this.waifuTraits = Array.from(new Set(WAIFUS.flatMap((item) => item.traits || []))).sort((a, b) =>
       a.localeCompare(b)
@@ -54,6 +181,7 @@ class AniRankerApp {
 
     this.restoreRatings();
     this.createLayout();
+    this.applyTheme(this.state.activeTheme);
     this.render();
     this.loadGenres();
     this.scheduleAnimeSearch();
@@ -92,10 +220,44 @@ class AniRankerApp {
   }
 
   setState(updates) {
+    const previousTheme = this.state.activeTheme;
     this.state = Object.assign({}, this.state, updates);
+    if (this.state.activeTheme !== previousTheme) {
+      this.applyTheme(this.state.activeTheme);
+    }
     if (this.isMounted) {
       this.render();
     }
+  }
+
+  applyTheme(themeId) {
+    if (!this.themePresets || this.themePresets.length === 0) {
+      return;
+    }
+    const preset = this.themePresets.find((item) => item.id === themeId) || this.themePresets[0];
+    if (!preset || !preset.palette) {
+      return;
+    }
+    const root = document.documentElement;
+    Object.entries(preset.palette).forEach(([key, value]) => {
+      if (typeof value === 'string') {
+        root.style.setProperty(key, value);
+      }
+    });
+    if (document.body) {
+      document.body.dataset.theme = preset.id;
+    }
+  }
+
+  handleThemeChange(themeId) {
+    if (!themeId || themeId === this.state.activeTheme) {
+      return;
+    }
+    const exists = this.themePresets && this.themePresets.some((item) => item.id === themeId);
+    if (!exists) {
+      return;
+    }
+    this.setState({ activeTheme: themeId });
   }
 
   scheduleAnimeSearch() {
@@ -170,13 +332,25 @@ class AniRankerApp {
 
     const header = document.createElement('header');
     header.className = 'app__header';
+    const badge = document.createElement('span');
+    badge.className = 'app__header-badge';
+    badge.textContent = 'Big five chakra mode';
     const heading = document.createElement('h1');
     heading.textContent = 'AniRanker';
     const subtitle = document.createElement('p');
-    subtitle.textContent = 'Curate a personal library of the stories that move you.';
+    subtitle.textContent = 'Curate a personal anime library and let legendary arcs guide your rankings.';
+    const note = document.createElement('p');
+    note.className = 'app__header-note';
+    note.textContent =
+      'Blend AniRanker with iconic palettes from Naruto, One Piece, Dragon Ball, Bleach, and Attack on Titan.';
+    header.appendChild(badge);
     header.appendChild(heading);
     header.appendChild(subtitle);
+    header.appendChild(note);
     app.appendChild(header);
+
+    this.themeSwitcher = this.createThemeSwitcher();
+    app.appendChild(this.themeSwitcher);
 
     this.waifuSection = this.createWaifuSection();
     app.appendChild(this.waifuSection);
@@ -215,6 +389,30 @@ class AniRankerApp {
     document.body.appendChild(this.detailOverlay);
 
     this.isMounted = true;
+  }
+
+  createThemeSwitcher() {
+    const section = document.createElement('section');
+    section.className = 'theme-switcher surface-card';
+
+    const header = document.createElement('div');
+    header.className = 'theme-switcher__header';
+    const title = document.createElement('h2');
+    title.className = 'theme-switcher__title';
+    title.textContent = 'Big five aura themes';
+    const description = document.createElement('p');
+    description.className = 'theme-switcher__description';
+    description.textContent =
+      'Tap into Naruto, One Piece, Dragon Ball, Bleach, and Attack on Titan energy instantly.';
+    header.appendChild(title);
+    header.appendChild(description);
+    section.appendChild(header);
+
+    this.themeSwitcherList = document.createElement('div');
+    this.themeSwitcherList.className = 'theme-switcher__list';
+    section.appendChild(this.themeSwitcherList);
+
+    return section;
   }
 
   createWaifuSection() {
@@ -363,10 +561,55 @@ class AniRankerApp {
     return overlay;
   }
 
+  renderThemeSwitcher() {
+    if (!this.themeSwitcherList) {
+      return;
+    }
+    this.themeSwitcherList.innerHTML = '';
+    this.themePresets.forEach((preset) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = preset.id === this.state.activeTheme ? 'theme-chip theme-chip--active' : 'theme-chip';
+      button.dataset.theme = preset.id;
+      button.setAttribute('aria-pressed', preset.id === this.state.activeTheme ? 'true' : 'false');
+      button.setAttribute('aria-label', `Activate ${preset.label} theme`);
+      button.addEventListener('click', () => this.handleThemeChange(preset.id));
+
+      const title = document.createElement('span');
+      title.className = 'theme-chip__title';
+      title.textContent = preset.label;
+      const tagline = document.createElement('span');
+      tagline.className = 'theme-chip__tagline';
+      tagline.textContent = preset.tagline;
+      const swatches = document.createElement('span');
+      swatches.className = 'theme-chip__swatches';
+      (preset.swatches || []).forEach((color) => {
+        const swatch = document.createElement('span');
+        swatch.className = 'theme-chip__swatch';
+        swatch.style.setProperty('--swatch-color', color);
+        swatches.appendChild(swatch);
+      });
+
+      button.appendChild(title);
+      button.appendChild(tagline);
+      button.appendChild(swatches);
+
+      if (preset.id === this.state.activeTheme) {
+        const status = document.createElement('span');
+        status.className = 'theme-chip__status';
+        status.textContent = 'Live theme';
+        button.appendChild(status);
+      }
+
+      this.themeSwitcherList.appendChild(button);
+    });
+  }
+
   render() {
     if (!this.isMounted) {
       return;
     }
+    this.renderThemeSwitcher();
     this.renderWaifuSection();
     this.renderFilterControls();
     this.renderAnimeSection();

--- a/styles.css
+++ b/styles.css
@@ -1,18 +1,24 @@
 :root {
   font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
-  color: #161b22;
+  color: var(--text-main);
   background-color: #f5f5f2;
   line-height: 1.6;
   --surface: #ffffff;
   --surface-muted: #f0f1f1;
+  --surface-gradient: linear-gradient(160deg, rgba(255, 255, 255, 0.95) 0%, rgba(245, 246, 247, 0.92) 100%);
   --accent: #bfa67a;
   --accent-strong: #a48857;
+  --accent-soft: rgba(191, 166, 122, 0.18);
   --text-main: #161b22;
   --text-muted: #6c727f;
   --border: #d9dce1;
   --border-strong: #c0c4cc;
   --shadow-soft: 0 22px 55px rgba(17, 23, 32, 0.08);
   --shadow-sharp: 0 8px 24px rgba(17, 23, 32, 0.08);
+  --app-background: linear-gradient(135deg, #f7f7f4 0%, #edefef 45%, #fdfdfb 100%);
+  --hero-glow: rgba(191, 166, 122, 0.35);
+  --hero-glow-secondary: rgba(191, 166, 122, 0.18);
+  --focus-ring: rgba(191, 166, 122, 0.35);
 }
 
 * {
@@ -22,9 +28,72 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: linear-gradient(135deg, #f7f7f4 0%, #edefef 45%, #fdfdfb 100%);
+  background: var(--app-background);
   color: var(--text-main);
   -webkit-font-smoothing: antialiased;
+  transition: background 0.6s ease, color 0.4s ease;
+  position: relative;
+}
+
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  inset: auto;
+  pointer-events: none;
+  border-radius: 50%;
+  filter: blur(0px);
+  opacity: 0.75;
+  z-index: -1;
+  background: radial-gradient(circle, var(--hero-glow) 0%, rgba(255, 255, 255, 0) 70%);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+  animation: auraFloat 18s ease-in-out infinite alternate;
+}
+
+body::before {
+  width: min(680px, 65vw);
+  height: min(680px, 65vw);
+  top: -25vh;
+  left: -20vw;
+}
+
+body::after {
+  width: min(520px, 55vw);
+  height: min(520px, 55vw);
+  bottom: -18vh;
+  right: -25vw;
+  background: radial-gradient(circle, var(--hero-glow-secondary) 0%, rgba(255, 255, 255, 0) 70%);
+  animation-duration: 22s;
+}
+
+@keyframes auraFloat {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 0.65;
+  }
+  50% {
+    transform: translate3d(1%, -2%, 0) scale(1.05);
+    opacity: 0.8;
+  }
+  100% {
+    transform: translate3d(-2%, 3%, 0) scale(1.1);
+    opacity: 0.65;
+  }
+}
+
+@keyframes headerPulse {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 0.75;
+  }
+  50% {
+    transform: translate3d(3%, -2%, 0) scale(1.05);
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(-2%, 3%, 0) scale(1.03);
+    opacity: 0.7;
+  }
 }
 
 a {
@@ -33,32 +102,134 @@ a {
 }
 
 .app {
-  max-width: 1120px;
+  max-width: 1160px;
   margin: 0 auto;
-  padding: 3.5rem 1.5rem 4rem;
+  padding: 3.5rem 1.5rem 4.5rem;
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 2.75rem;
+  position: relative;
+  z-index: 1;
 }
 
 .app__header {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.9rem;
   text-align: center;
+  padding: 3rem 2.75rem;
+  border-radius: 32px;
+  border: 1px solid var(--border);
+  background: var(--surface-gradient);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+  isolation: isolate;
+  align-items: center;
+}
+
+.app__header::before,
+.app__header::after {
+  content: "";
+  position: absolute;
+  inset: auto;
+  border-radius: 50%;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  opacity: 0.8;
+  transition: opacity 0.4s ease, transform 0.4s ease;
+}
+
+.app__header::before {
+  width: min(480px, 50vw);
+  height: min(480px, 50vw);
+  top: -30%;
+  right: -20%;
+  background: radial-gradient(circle at top, var(--hero-glow) 0%, rgba(255, 255, 255, 0) 70%);
+  animation: headerPulse 16s ease-in-out infinite alternate;
+}
+
+.app__header::after {
+  width: min(420px, 46vw);
+  height: min(420px, 46vw);
+  bottom: -25%;
+  left: -20%;
+  background: radial-gradient(circle at bottom, var(--hero-glow-secondary) 0%, rgba(255, 255, 255, 0) 70%);
+  animation: headerPulse 18s ease-in-out infinite alternate-reverse;
+}
+
+.app__header:hover::before,
+.app__header:hover::after {
+  opacity: 1;
+  transform: translate3d(0, -2%, 0) scale(1.05);
+}
+
+.app__header-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  color: var(--accent);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  box-shadow: var(--shadow-sharp);
 }
 
 .app__header h1 {
   margin: 0;
-  font-weight: 600;
-  font-size: clamp(2.25rem, 4vw, 3rem);
+  font-weight: 700;
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
   letter-spacing: -0.02em;
+  text-shadow: 0 12px 35px rgba(0, 0, 0, 0.12);
 }
 
 .app__header p {
   margin: 0;
   color: var(--text-muted);
   font-size: 1.05rem;
+  max-width: 620px;
+}
+
+.app__header-note {
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  color: color-mix(in srgb, var(--text-muted) 90%, var(--accent) 10%);
+}
+
+.surface-card {
+  position: relative;
+  background: var(--surface-gradient);
+  border-radius: 26px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+  isolation: isolate;
+  transition: background 0.4s ease, border-color 0.4s ease, box-shadow 0.4s ease, transform 0.35s ease;
+}
+
+.surface-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0) 65%);
+  mix-blend-mode: screen;
+  pointer-events: none;
+  opacity: 0.65;
+  transition: opacity 0.3s ease;
+}
+
+.surface-card:hover {
+  box-shadow: var(--shadow-sharp);
+  transform: translateY(-4px);
+}
+
+.surface-card:hover::before {
+  opacity: 0.85;
 }
 
 .surface-card {
@@ -74,24 +245,158 @@ a {
   gap: 0.45rem;
   padding: 0.6rem 1.15rem;
   border-radius: 999px;
-  border: 1px solid var(--border);
-  background: var(--surface);
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92) 0%, rgba(255, 255, 255, 0.7) 100%);
   font-size: 0.85rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-muted);
   cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+  transform: translateY(0);
+  box-shadow: 0 12px 24px rgba(15, 23, 32, 0.08);
+  transition: transform 0.25s ease, border-color 0.3s ease, box-shadow 0.3s ease, color 0.3s ease, background 0.3s ease;
 }
 
 .section-toggle:hover {
   border-color: var(--accent);
   color: var(--text-main);
   box-shadow: var(--shadow-sharp);
+  transform: translateY(-2px);
 }
 
 .section-toggle:focus-visible {
-  outline: 2px solid rgba(191, 166, 122, 0.35);
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+.theme-switcher {
+  padding: 1.95rem 2.25rem;
+  display: grid;
+  gap: 1.6rem;
+}
+
+.theme-switcher__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  text-align: center;
+  align-items: center;
+}
+
+.theme-switcher__title {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.theme-switcher__description {
+  margin: 0;
+  color: color-mix(in srgb, var(--text-muted) 80%, var(--accent) 20%);
+  font-size: 0.95rem;
+  max-width: 520px;
+}
+
+.theme-switcher__list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 1.1rem;
+}
+
+.theme-chip {
+  position: relative;
+  display: grid;
+  gap: 0.65rem;
+  align-content: start;
+  padding: 1.1rem 1.2rem 1.25rem;
+  border-radius: 22px;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  background: color-mix(in srgb, var(--surface) 88%, rgba(255, 255, 255, 0.08) 12%);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 16px 35px rgba(17, 23, 32, 0.12);
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+  transition: transform 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease, background 0.35s ease;
+}
+
+.theme-chip::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.6) 0%, rgba(255, 255, 255, 0) 70%);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+}
+
+.theme-chip__title {
+  font-weight: 600;
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+}
+
+.theme-chip__tagline {
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--text-muted) 88%, var(--accent) 12%);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.theme-chip__swatches {
+  display: inline-flex;
+  gap: 0.4rem;
+}
+
+.theme-chip__swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--swatch-color, var(--accent));
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.65), 0 4px 12px rgba(17, 23, 32, 0.22);
+  transition: transform 0.3s ease;
+}
+
+.theme-chip__status {
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--accent) 65%, var(--text-muted) 35%);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.theme-chip:hover {
+  transform: translateY(-4px);
+  border-color: var(--accent);
+  box-shadow: var(--shadow-sharp);
+}
+
+.theme-chip:hover::after {
+  opacity: 1;
+}
+
+.theme-chip:hover .theme-chip__swatch {
+  transform: scale(1.05);
+}
+
+.theme-chip--active {
+  border-color: var(--accent);
+  background: linear-gradient(135deg,
+      color-mix(in srgb, var(--surface) 85%, var(--accent-soft) 15%) 0%,
+      color-mix(in srgb, var(--surface) 65%, var(--accent-soft) 35%) 100%);
+  box-shadow: var(--shadow-sharp);
+  transform: translateY(-6px);
+}
+
+.theme-chip--active::after {
+  opacity: 1;
+}
+
+.theme-chip:focus-visible {
+  outline: 2px solid var(--focus-ring);
   outline-offset: 3px;
 }
 
@@ -130,12 +435,20 @@ a {
 .waifu-selector__preview-card {
   padding: 1.1rem;
   border-radius: 20px;
-  background: var(--surface-muted);
+  background: color-mix(in srgb, var(--surface) 92%, var(--accent-soft) 8%);
   display: flex;
   gap: 1.1rem;
   align-items: stretch;
-  border: 1px solid rgba(22, 27, 34, 0.08);
+  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
   grid-column: 1 / -1;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  transition: transform 0.35s ease, background 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease;
+}
+
+.waifu-selector__preview-card:hover {
+  transform: translateY(-3px);
+  border-color: var(--accent);
+  box-shadow: var(--shadow-sharp);
 }
 
 .waifu-selector__preview-image {
@@ -143,6 +456,11 @@ a {
   border-radius: 16px;
   object-fit: cover;
   box-shadow: var(--shadow-sharp);
+  transition: transform 0.4s ease;
+}
+
+.waifu-selector__preview-card:hover .waifu-selector__preview-image {
+  transform: translateY(-4px);
 }
 
 .waifu-selector__preview-placeholder {
@@ -221,8 +539,12 @@ a {
   gap: 1.2rem;
   padding: 1rem 1.25rem;
   border-radius: 18px;
-  border: 1px solid rgba(22, 27, 34, 0.08);
-  background: rgba(15, 23, 32, 0.04);
+  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+  background: linear-gradient(145deg,
+      color-mix(in srgb, var(--surface) 88%, var(--accent-soft) 12%) 0%,
+      color-mix(in srgb, var(--surface) 95%, rgba(255, 255, 255, 0.85) 5%) 100%);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  transition: background 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease;
 }
 
 .waifu-selector__controls {
@@ -282,19 +604,24 @@ a {
 .trait-chip {
   padding: 0.45rem 0.85rem;
   border-radius: 999px;
-  border: 1px solid transparent;
-  background: var(--surface-muted);
+  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+  background: linear-gradient(135deg,
+      color-mix(in srgb, var(--surface) 88%, var(--accent-soft) 12%) 0%,
+      color-mix(in srgb, var(--surface) 82%, rgba(255, 255, 255, 0.85) 18%) 100%);
   font-size: 0.85rem;
   letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--text-muted);
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: transform 0.3s ease, background 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease, color 0.35s ease;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  transform: translateY(0);
 }
 
 .trait-chip:hover {
   border-color: var(--accent);
   color: var(--text-main);
+  transform: translateY(-2px);
 }
 
 .trait-chip--active {
@@ -302,6 +629,7 @@ a {
   color: #ffffff;
   border-color: var(--text-main);
   box-shadow: var(--shadow-sharp);
+  transform: translateY(-3px);
 }
 
 .waifu-selector__gallery {
@@ -325,9 +653,11 @@ a {
 }
 
 .waifu-pill {
-  border: 1px solid transparent;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   border-radius: 999px;
-  background: var(--surface-muted);
+  background: linear-gradient(135deg,
+      color-mix(in srgb, var(--surface) 90%, var(--accent-soft) 10%) 0%,
+      color-mix(in srgb, var(--surface) 85%, rgba(255, 255, 255, 0.85) 15%) 100%);
   color: var(--text-main);
   display: inline-flex;
   align-items: center;
@@ -335,8 +665,9 @@ a {
   padding: 0.55rem 1.1rem;
   font-size: 0.9rem;
   cursor: pointer;
-  transition: all 0.2s ease;
-  box-shadow: none;
+  transition: transform 0.3s ease, background 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease, color 0.35s ease;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  transform: translateY(0);
 }
 
 .waifu-pill strong {
@@ -357,6 +688,7 @@ a {
 .waifu-pill:hover {
   border-color: var(--accent);
   box-shadow: var(--shadow-sharp);
+  transform: translateY(-3px);
 }
 
 .waifu-pill--active {
@@ -364,6 +696,7 @@ a {
   color: #ffffff;
   border-color: var(--text-main);
   box-shadow: var(--shadow-sharp);
+  transform: translateY(-3px);
 }
 
 .waifu-pill--active span,
@@ -373,15 +706,11 @@ a {
 
 button.waifu-pill {
   border: none;
-  background: var(--surface-muted);
-}
-
-button.waifu-pill.waifu-pill--active {
-  background: var(--text-main);
+  background: none;
 }
 
 button.waifu-pill:focus-visible {
-  outline: 2px solid rgba(191, 166, 122, 0.35);
+  outline: 2px solid var(--focus-ring);
   outline-offset: 3px;
 }
 
@@ -431,7 +760,7 @@ button.waifu-pill:focus-visible {
 .input-shell__control:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 4px rgba(191, 166, 122, 0.15);
+  box-shadow: 0 0 0 4px var(--accent-soft);
 }
 
 .select-shell {
@@ -452,7 +781,7 @@ button.waifu-pill:focus-visible {
 .select-shell select:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 4px rgba(191, 166, 122, 0.15);
+  box-shadow: 0 0 0 4px var(--accent-soft);
 }
 
 .select-shell__icon,
@@ -495,17 +824,22 @@ button.waifu-pill:focus-visible {
   gap: 0.45rem;
   padding: 0.55rem 1rem;
   border-radius: 999px;
-  border: 1px solid transparent;
-  background: #eef0f0;
+  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+  background: linear-gradient(135deg,
+      color-mix(in srgb, var(--surface) 88%, var(--accent-soft) 12%) 0%,
+      color-mix(in srgb, var(--surface) 82%, rgba(255, 255, 255, 0.85) 18%) 100%);
   color: var(--text-muted);
   font-size: 0.9rem;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: transform 0.3s ease, background 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease, color 0.35s ease;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  transform: translateY(0);
 }
 
 .chip:hover {
   border-color: var(--accent);
   color: var(--text-main);
+  transform: translateY(-3px);
 }
 
 .chip--active {
@@ -513,11 +847,22 @@ button.waifu-pill:focus-visible {
   color: #ffffff;
   border-color: var(--text-main);
   box-shadow: var(--shadow-sharp);
+  transform: translateY(-3px);
 }
 
 .chip__icon {
   width: 16px;
   height: 16px;
+  color: var(--accent);
+  transition: color 0.3s ease;
+}
+
+.chip:hover .chip__icon {
+  color: var(--accent-strong);
+}
+
+.chip--active .chip__icon {
+  color: #ffffff;
 }
 
 .chip input {
@@ -543,15 +888,18 @@ button.waifu-pill:focus-visible {
   flex-direction: column;
   overflow: hidden;
   border-radius: 24px;
-  border: 1px solid var(--border);
-  background: var(--surface);
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  background: linear-gradient(160deg,
+      color-mix(in srgb, var(--surface) 92%, var(--accent-soft) 8%) 0%,
+      color-mix(in srgb, var(--surface) 86%, rgba(255, 255, 255, 0.85) 14%) 100%);
   box-shadow: var(--shadow-soft);
-  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease, background 0.35s ease;
 }
 
 .anime-card:hover {
-  transform: translateY(-6px);
-  box-shadow: 0 28px 60px rgba(17, 23, 32, 0.12);
+  transform: translateY(-8px);
+  box-shadow: 0 32px 70px rgba(17, 23, 32, 0.2);
+  border-color: var(--accent);
 }
 
 .anime-card__cover {
@@ -559,6 +907,8 @@ button.waifu-pill:focus-visible {
   padding: 0;
   background: none;
   cursor: pointer;
+  overflow: hidden;
+  position: relative;
 }
 
 .anime-card__cover img {
@@ -566,6 +916,11 @@ button.waifu-pill:focus-visible {
   width: 100%;
   aspect-ratio: 3 / 4;
   object-fit: cover;
+  transition: transform 0.5s ease;
+}
+
+.anime-card:hover .anime-card__cover img {
+  transform: scale(1.05);
 }
 
 .anime-card__placeholder {
@@ -603,9 +958,12 @@ button.waifu-pill:focus-visible {
   gap: 0.4rem;
   padding: 0.45rem 0.7rem;
   border-radius: 999px;
-  background: var(--surface-muted);
-  color: var(--text-muted);
+  background: linear-gradient(135deg,
+      color-mix(in srgb, var(--surface) 90%, var(--accent-soft) 10%) 0%,
+      color-mix(in srgb, var(--surface) 85%, rgba(255, 255, 255, 0.85) 15%) 100%);
+  color: color-mix(in srgb, var(--text-muted) 90%, var(--accent) 10%);
   font-size: 0.85rem;
+  transition: background 0.3s ease, color 0.3s ease;
 }
 
 .metric__icon {
@@ -626,7 +984,18 @@ button.waifu-pill:focus-visible {
   gap: 0.75rem;
   padding: 0.95rem 1.15rem;
   border-radius: 18px;
-  background: var(--surface-muted);
+  background: linear-gradient(135deg,
+      color-mix(in srgb, var(--surface) 92%, var(--accent-soft) 8%) 0%,
+      color-mix(in srgb, var(--surface) 86%, rgba(255, 255, 255, 0.85) 14%) 100%);
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  transition: transform 0.35s ease, background 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease;
+}
+
+.rating-control:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+  box-shadow: var(--shadow-sharp);
 }
 
 .rating-control__label {
@@ -679,7 +1048,7 @@ button.waifu-pill:focus-visible {
 }
 
 .star-button:focus-visible {
-  outline: 2px solid rgba(191, 166, 122, 0.4);
+  outline: 2px solid var(--focus-ring);
   outline-offset: 3px;
 }
 
@@ -712,23 +1081,31 @@ button.waifu-pill:focus-visible {
   font-weight: 600;
   font-size: 0.95rem;
   letter-spacing: 0.02em;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease;
+  position: relative;
+  overflow: hidden;
+  transform: translateY(0);
 }
 
 .button--primary {
-  background: var(--text-main);
+  background: linear-gradient(135deg, var(--text-main) 0%, color-mix(in srgb, var(--text-main) 70%, var(--accent-strong) 30%) 100%);
   color: #ffffff;
   box-shadow: var(--shadow-sharp);
 }
 
 .button--primary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 16px 25px rgba(17, 23, 32, 0.16);
+  transform: translateY(-3px);
+  box-shadow: 0 20px 32px rgba(17, 23, 32, 0.24);
 }
 
 .button__icon {
   width: 16px;
   height: 16px;
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
 }
 
 .status-message {
@@ -744,12 +1121,13 @@ button.waifu-pill:focus-visible {
 .detail-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(12, 18, 26, 0.55);
+  background: color-mix(in srgb, rgba(12, 18, 26, 0.75) 70%, var(--hero-glow) 30%);
   display: grid;
   place-items: center;
   padding: 2rem;
   backdrop-filter: blur(8px);
   z-index: 20;
+  animation: overlayFade 0.45s ease;
 }
 
 .detail-modal {
@@ -757,8 +1135,8 @@ button.waifu-pill:focus-visible {
   max-width: 860px;
   width: min(860px, 100%);
   border-radius: 28px;
-  border: 1px solid var(--border-strong);
-  background: var(--surface);
+  border: 1px solid color-mix(in srgb, var(--border-strong) 80%, transparent);
+  background: var(--surface-gradient);
   box-shadow: 0 30px 65px rgba(10, 14, 20, 0.35);
   padding: 2.5rem 2.75rem;
   display: flex;
@@ -766,6 +1144,7 @@ button.waifu-pill:focus-visible {
   gap: 1.9rem;
   max-height: 90vh;
   overflow-y: auto;
+  animation: modalRise 0.45s ease;
 }
 
 .detail-modal__close {
@@ -848,6 +1227,37 @@ button.waifu-pill:focus-visible {
   display: flex;
   flex-wrap: wrap;
   gap: 0.55rem;
+}
+
+@keyframes overlayFade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes modalRise {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 28px, 0) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 .detail-modal__waifu-list .waifu-pill {


### PR DESCRIPTION
## Summary
- add Big Five anime theme presets and a theme switcher component to let users restyle the app instantly
- refresh the global styling with anime-inspired gradients, header badge, and supportive copy
- polish chips, cards, and overlays with motion, focus, and hover treatments tied to each theme

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c9b69224f48324a45e422a1d900583